### PR TITLE
Fix Typo and Add Placeholder Data Page

### DIFF
--- a/data.html
+++ b/data.html
@@ -16,32 +16,21 @@
 		<div id="logo"><img src="images/logo.png">The MeLa Lab</div>
 		<nav>
 			<ul>
-        <li><a href="index.html">Home</a>
+				<li><a href="index.html">Home</a>
 				<li><a href="members.html">Members</a>
 				<li><a href="publications.html">Publications</a>
-        		<li><a href="data.html">Data</a>
+        		<li><a href="">Data</a>
 				<li><a href="https://github.com/MELALab">GitHub</a>
 			</ul>
 		</nav>
 	</header>
 	<section>
-		<strong>Welcome to The Media Landscape (MeLa) Lab.</strong>
+		<strong>Datasets</strong>
 	</section>
 	<section id="pageContent">
 		<main role="main">
-			<article>
-				<h2>What is The MeLa Lab?</h2>
-				<p>The Media Landscape Lab is a multi-university group of researchers that work on problems related to online news and media.</p>
-			</article>
+			<p>Every dataset we release will appear here. Current work is pending publication.</p>
 		</main>
-		<aside>
-			<div> <!-- News side bar here! -->
-        <h2>News:</h2><br>
-          <ul>
-            <li>MeLa Lab Website Launched!</li>
-          </ul>
-      </div>
-		</aside>
 	</section>
 	<footer>
 		<p><b>Contact:</b> benjamindhorne314 at gmail dot com <b>|</b> Layout Template: <a href="https://html5-templates.com/" target="_blank" rel="nofollow">HTML5 Templates</a></p>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 		<main role="main">
 			<article>
 				<h2>What is The MeLa Lab?</h2>
-				<p>The Media Landscape Lab is a multi-universiy group of researchers that work on problems related to online news and media.</p>
+				<p>The Media Landscape Lab is a multi-university group of researchers that work on problems related to online news and media.</p>
 			</article>
 		</main>
 		<aside>

--- a/members.html
+++ b/members.html
@@ -19,7 +19,7 @@
 				<li><a href="index.html">Home</a>
 				<li><a href="members.html">Members</a>
 				<li><a href="publications.html">Publications</a>
-        <li><a href="">Data</a>
+        		<li><a href="data.html">Data</a>
 				<li><a href="https://github.com/MELALab">GitHub</a>
 			</ul>
 		</nav>

--- a/publications.html
+++ b/publications.html
@@ -19,7 +19,7 @@
 				<li><a href="index.html">Home</a>
 				<li><a href="members.html">Members</a>
 				<li><a href="publications.html">Publications</a>
-        <li><a href="">Data</a>
+        		<li><a href="data.html">Data</a>
 				<li><a href="https://github.com/MELALab">GitHub</a>
 			</ul>
 		</nav>


### PR DESCRIPTION
"university" was misspelled on the front page, and an empty link to "Data" on the navbar was unintuitive, so I think we should either remove the link until we release our first dataset, or put up a placeholder page. This includes the latter.